### PR TITLE
remove error displayed on console in case of token renewal

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,7 +302,6 @@ class Freebox {
 		try {
 			response = await this._getAxiosInstance().request(requestConfig);
 		} catch (error) {
-			console.log(error);
 			const {status, data} = error.response;
 			const {
 				error_code,
@@ -314,6 +313,7 @@ class Freebox {
 				this.headers['X-Fbx-App-Auth'];
 
 			if (!isTokenExpired) {
+				console.log(error);
 				throw error;
 			}
 


### PR DESCRIPTION
Hi,

The goal is to avoid pollution of the console logs at every token renewal (every 30 minutes for me).
The error continues to be displayed for other 'real' error cases.

Regards.
