### PR TITLE
Ajout du "type":"module" dans le package.json pour typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
     "rules": {
       "camelcase": 0
     }
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
Fix l'erreur que j'ai en utilisant le package avec typescript : 
```
C:\dev\traefik-conf\node_modules\freebox\index.js:1
import https from 'node:https';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at Object.compileFunction (node:vm:360:18)
    at wrapSafe (node:internal/modules/cjs/loader:1088:15)
    at Module._compile (node:internal/modules/cjs/loader:1123:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:530:24)

Node.js v18.11.0
```
